### PR TITLE
Increase load experiments

### DIFF
--- a/src/aviation/sql/by_route_load+1p.sql
+++ b/src/aviation/sql/by_route_load+1p.sql
@@ -1,0 +1,40 @@
+
+WITH airlines AS (
+    SELECT * FROM read_csv_auto('data/flight_emission_data_2025-01-17/airline.csv', header=true)
+)
+
+, routes AS (
+    SELECT * FROM read_csv_auto('data/flight_emission_data_2025-01-17/emissionV22_2025-02-24.csv', header=true)
+)
+
+, airports AS (
+    SELECT * FROM read_csv_auto('data/flight_emission_data_2025-01-17/airport.csv', header=true)
+)
+
+SELECT
+    emissionflightinfo_departureiatacode as departure,
+    emissionflightinfo_arrivaliatacode as arrival,
+    FIRST(airports_a.longitude) as arrival_longitude,
+    FIRST(airports_a.latitude) as arrival_latitude,
+    FIRST(airports_d.longitude) as departure_longitude,
+    FIRST(airports_d.latitude) as departure_latitude,
+    COUNT(DISTINCT aircraftiatacode) AS aircraft_types,
+    COUNT(DISTINCT airlinename) AS airlines,
+    SUM(emissionflightinfo_flightdistancekm * frequency) / SUM(frequency) AS avg_distance,
+    SUM(emissionflightinfo_flightdistancekm * frequency) AS flown_distance,
+    SUM(emissionflightinfo_greatcircledistancekm * frequency) AS gcd,
+    SUM(frequency) AS flights,
+    SUM(LEAST(emissionflightinfo_passengerloadfactor+0.01, 1) * seatcount * frequency) AS passengers,
+    SUM(seatcount * frequency) AS seats,
+    SUM(LEAST(emissionflightinfo_passengerloadfactor+0.01, 1) * frequency) / SUM(frequency) AS average_load,
+    SUM(values_averageclass_co2withoutrfiperpassengerintons * frequency * LEAST(emissionflightinfo_passengerloadfactor + 0.01, 1) * seatcount) AS co2,
+    SUM(values_averageclass_co2withoutrfiperpassengerintons / emissionflightinfo_flightdistancekm * frequency)
+        / SUM(frequency)
+        * 1000 * 1000
+    AS gco2_pax_km,
+FROM routes, airports as airports_a, airports as airports_d
+WHERE
+    airports_d.iatacode = emissionflightinfo_departureiatacode AND
+    airports_a.iatacode = emissionflightinfo_arrivaliatacode
+GROUP BY departure, arrival
+ORDER BY passengers DESC

--- a/src/aviation/sql/by_route_load+2p.sql
+++ b/src/aviation/sql/by_route_load+2p.sql
@@ -1,0 +1,40 @@
+
+WITH airlines AS (
+    SELECT * FROM read_csv_auto('data/flight_emission_data_2025-01-17/airline.csv', header=true)
+)
+
+, routes AS (
+    SELECT * FROM read_csv_auto('data/flight_emission_data_2025-01-17/emissionV22_2025-02-24.csv', header=true)
+)
+
+, airports AS (
+    SELECT * FROM read_csv_auto('data/flight_emission_data_2025-01-17/airport.csv', header=true)
+)
+
+SELECT
+    emissionflightinfo_departureiatacode as departure,
+    emissionflightinfo_arrivaliatacode as arrival,
+    FIRST(airports_a.longitude) as arrival_longitude,
+    FIRST(airports_a.latitude) as arrival_latitude,
+    FIRST(airports_d.longitude) as departure_longitude,
+    FIRST(airports_d.latitude) as departure_latitude,
+    COUNT(DISTINCT aircraftiatacode) AS aircraft_types,
+    COUNT(DISTINCT airlinename) AS airlines,
+    SUM(emissionflightinfo_flightdistancekm * frequency) / SUM(frequency) AS avg_distance,
+    SUM(emissionflightinfo_flightdistancekm * frequency) AS flown_distance,
+    SUM(emissionflightinfo_greatcircledistancekm * frequency) AS gcd,
+    SUM(frequency) AS flights,
+    SUM(LEAST(emissionflightinfo_passengerloadfactor+0.02, 1) * seatcount * frequency) AS passengers,
+    SUM(seatcount * frequency) AS seats,
+    SUM(LEAST(emissionflightinfo_passengerloadfactor+0.02, 1) * frequency) / SUM(frequency) AS average_load,
+    SUM(values_averageclass_co2withoutrfiperpassengerintons * frequency * LEAST(emissionflightinfo_passengerloadfactor + 0.02, 1) * seatcount) AS co2,
+    SUM(values_averageclass_co2withoutrfiperpassengerintons / emissionflightinfo_flightdistancekm * frequency)
+        / SUM(frequency)
+        * 1000 * 1000
+    AS gco2_pax_km,
+FROM routes, airports as airports_a, airports as airports_d
+WHERE
+    airports_d.iatacode = emissionflightinfo_departureiatacode AND
+    airports_a.iatacode = emissionflightinfo_arrivaliatacode
+GROUP BY departure, arrival
+ORDER BY passengers DESC

--- a/src/aviation/sql/by_route_load+5p.sql
+++ b/src/aviation/sql/by_route_load+5p.sql
@@ -1,0 +1,40 @@
+
+WITH airlines AS (
+    SELECT * FROM read_csv_auto('data/flight_emission_data_2025-01-17/airline.csv', header=true)
+)
+
+, routes AS (
+    SELECT * FROM read_csv_auto('data/flight_emission_data_2025-01-17/emissionV22_2025-02-24.csv', header=true)
+)
+
+, airports AS (
+    SELECT * FROM read_csv_auto('data/flight_emission_data_2025-01-17/airport.csv', header=true)
+)
+
+SELECT
+    emissionflightinfo_departureiatacode as departure,
+    emissionflightinfo_arrivaliatacode as arrival,
+    FIRST(airports_a.longitude) as arrival_longitude,
+    FIRST(airports_a.latitude) as arrival_latitude,
+    FIRST(airports_d.longitude) as departure_longitude,
+    FIRST(airports_d.latitude) as departure_latitude,
+    COUNT(DISTINCT aircraftiatacode) AS aircraft_types,
+    COUNT(DISTINCT airlinename) AS airlines,
+    SUM(emissionflightinfo_flightdistancekm * frequency) / SUM(frequency) AS avg_distance,
+    SUM(emissionflightinfo_flightdistancekm * frequency) AS flown_distance,
+    SUM(emissionflightinfo_greatcircledistancekm * frequency) AS gcd,
+    SUM(frequency) AS flights,
+    SUM(LEAST(emissionflightinfo_passengerloadfactor+0.05, 1) * seatcount * frequency) AS passengers,
+    SUM(seatcount * frequency) AS seats,
+    SUM(LEAST(emissionflightinfo_passengerloadfactor+0.05, 1) * frequency) / SUM(frequency) AS average_load,
+    SUM(values_averageclass_co2withoutrfiperpassengerintons * frequency * LEAST(emissionflightinfo_passengerloadfactor + 0.05, 1) * seatcount) AS co2,
+    SUM(values_averageclass_co2withoutrfiperpassengerintons / emissionflightinfo_flightdistancekm * frequency)
+        / SUM(frequency)
+        * 1000 * 1000
+    AS gco2_pax_km,
+FROM routes, airports as airports_a, airports as airports_d
+WHERE
+    airports_d.iatacode = emissionflightinfo_departureiatacode AND
+    airports_a.iatacode = emissionflightinfo_arrivaliatacode
+GROUP BY departure, arrival
+ORDER BY passengers DESC

--- a/src/aviation/sql/by_route_load1.sql
+++ b/src/aviation/sql/by_route_load1.sql
@@ -1,0 +1,40 @@
+
+WITH airlines AS (
+    SELECT * FROM read_csv_auto('data/flight_emission_data_2025-01-17/airline.csv', header=true)
+)
+
+, routes AS (
+    SELECT * FROM read_csv_auto('data/flight_emission_data_2025-01-17/emissionV22_2025-02-24.csv', header=true)
+)
+
+, airports AS (
+    SELECT * FROM read_csv_auto('data/flight_emission_data_2025-01-17/airport.csv', header=true)
+)
+
+SELECT
+    emissionflightinfo_departureiatacode as departure,
+    emissionflightinfo_arrivaliatacode as arrival,
+    FIRST(airports_a.longitude) as arrival_longitude,
+    FIRST(airports_a.latitude) as arrival_latitude,
+    FIRST(airports_d.longitude) as departure_longitude,
+    FIRST(airports_d.latitude) as departure_latitude,
+    COUNT(DISTINCT aircraftiatacode) AS aircraft_types,
+    COUNT(DISTINCT airlinename) AS airlines,
+    SUM(emissionflightinfo_flightdistancekm * frequency) / SUM(frequency) AS avg_distance,
+    SUM(emissionflightinfo_flightdistancekm * frequency) AS flown_distance,
+    SUM(emissionflightinfo_greatcircledistancekm * frequency) AS gcd,
+    SUM(frequency) AS flights,
+    SUM(1 * seatcount * frequency) AS passengers,
+    SUM(seatcount * frequency) AS seats,
+    SUM(1 * frequency) / SUM(frequency) AS average_load,
+    SUM(values_averageclass_co2withoutrfiperpassengerintons * frequency * 1 * seatcount) AS co2,
+    SUM(values_averageclass_co2withoutrfiperpassengerintons / emissionflightinfo_flightdistancekm * frequency)
+        / SUM(frequency)
+        * 1000 * 1000
+    AS gco2_pax_km,
+FROM routes, airports as airports_a, airports as airports_d
+WHERE
+    airports_d.iatacode = emissionflightinfo_departureiatacode AND
+    airports_a.iatacode = emissionflightinfo_arrivaliatacode
+GROUP BY departure, arrival
+ORDER BY passengers DESC


### PR DESCRIPTION
@jorgecardleitao I've created 4 sql files with 4 experiments. I thought it's the easiest and most correct to do it like this as

$$ min(l + 0.01, 1) * seatcount * flights ...$$

(increase load factor by 1%) isn't a linear operation so you can't just do `/1.01` on the final CO2 emissions.

Experiment 1) set the load factor to 1 for all flights
Experiment 2-4) increase the load factor by 1%, 2%, 5%

For experiments 2-4 we can then check how linear this is in practice. Does this make sense?